### PR TITLE
Fixed gson field name

### DIFF
--- a/CoreCommon/src/main/java/com/hitherejoe/bourboncorecommon/data/model/User.java
+++ b/CoreCommon/src/main/java/com/hitherejoe/bourboncorecommon/data/model/User.java
@@ -3,12 +3,16 @@ package com.hitherejoe.bourboncorecommon.data.model;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import com.google.gson.annotations.SerializedName;
+
 public class User implements Parcelable {
 
     public int id;
     public String name;
     public String username;
+    @SerializedName("html_url")
     public String htmlUrl;
+    @SerializedName("avatar_url")
     public String avatarUrl;
 
     @Override


### PR DESCRIPTION
API response gson of `user` has `html_url` and `avatar_url`.

```json
    "user": {
      "id": 285475,
      "name": "Markus Magnusson ",
      "username": "MarkusM",
      "html_url": "https://dribbble.com/MarkusM",
      "avatar_url": "https://d13yacurqjgara.cloudfront.net/users/285475/avatars/normal/7ab1fc9d69e079e2dc11095fd74908cf.png?1432660315",
      "bio": "<a href=\"https://instagram.com/motionmarkus/\" rel=\"nofollow noreferrer\">instagram.com/motionmarkus</a>\n",
      "location": "Sweden",
      "links": {
        "web": "http://markusmagnusson.tv",
        "twitter": "https://twitter.com/MotionMarkus"
      },

```

But the field names of user model are different.

```java
public class User implements Parcelable {

    public String htmlUrl;
    public String avatarUrl;
```

So I added `@SerializedName` annotation.